### PR TITLE
Add the ability to add custom metadata to instances

### DIFF
--- a/charts/crunchy-postgres/Chart.yaml
+++ b/charts/crunchy-postgres/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/crunchy-postgres/README.md
+++ b/charts/crunchy-postgres/README.md
@@ -14,11 +14,12 @@ A chart to provision a [Crunchy Postgres](https://www.crunchydata.com/) cluster.
 
 ---
 
-###w Instances
+### Instances - Specifies one or more sets of PostgreSQL pods that replicate data for this cluster.
 
 | Parameter                                   | Description                    | Default                  |
 | ------------------------------------------- | ------------------------------ | ------------------------ |
 | `instances.name`                            | Instance name                  | `ha` (high availability) |
+| `instances.metadata`                        | Instance custom metadata       |                          |
 | `instances.replicas`                        | Number of replicas             | `2`                      |
 | `instances.dataVolumeClaimSpec.storage`     | Amount of storage for each PVC | `480Mi`                  |
 | `instances.requests.cpu`                    | CPU requests                   | `1m`                     |
@@ -100,6 +101,16 @@ A lightweight connection pooler for PostgreSQL
 | Parameter           | Description                                    | Default |
 | ------------------- | ---------------------------------------------- | ------- |
 | `pgmonitor.enabled` | Enable PG Monitor (currently only PG exporter) | `false` |
+
+When enabling PG Monitor you can should add annoations to the instances to inform Sysdig to scrap the metrics,
+
+```yaml
+instances:
+  metadata:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9187'
+```
 
 #### Postgres Exporter
 

--- a/charts/crunchy-postgres/templates/PostgresCluster.yaml
+++ b/charts/crunchy-postgres/templates/PostgresCluster.yaml
@@ -32,6 +32,10 @@ spec:
 
   instances:
     - name: {{ .Values.instances.name }}
+      {{- if .Values.instances.metadata }}
+      metadata:
+        {{- toYaml .Values.instances.metadata | nindent 8 }}
+      {{- end }}
       replicas: {{ .Values.instances.replicas }}
       resources:
         requests:

--- a/charts/crunchy-postgres/values.yaml
+++ b/charts/crunchy-postgres/values.yaml
@@ -6,6 +6,8 @@ postgresVersion: 14
 
 instances:
   name: ha # high availability
+  ## @param instances.metadata Custom labels or annotations for the instance pods
+  metadata: {}
   replicas: 2
   dataVolumeClaimSpec:
     storage: 480Mi


### PR DESCRIPTION
This PR adds the ability to add custom metadata to the instances. The instances are the pods where the postgres exporter runs. This allows adding the correct annotations for sysdig to pull metrics.

`my-values.yaml`

```yaml
instances:
  metadata:
    annotations:
      prometheus.io/scrape: 'true'
      prometheus.io/port: '9187'

pgmonitor:
  enabled: true
```

Deploy: `helm upgrade --install sysdig-demo crunchy-postgres --values my-values.yaml`

Once deployed, the metrics will show up in sysdig automatically.

![image](https://github.com/bcgov/crunchy-postgres/assets/1844480/96da6ac7-eca8-40e1-9269-b40f1c319d13)

and the default dashboards will work, for example,

![image](https://github.com/bcgov/crunchy-postgres/assets/1844480/a7f1dceb-b114-417a-927c-767e0fefc304)

