### PR TITLE
chore: bump crunchy-postgres chart version to v.0.5.1

### DIFF
--- a/charts/crunchy-postgres/Chart.yaml
+++ b/charts/crunchy-postgres/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
New minor version so we can create a new release