### PR TITLE
Update PostgresCluster.yaml

### DIFF
--- a/charts/crunchy-postgres/templates/PostgresCluster.yaml
+++ b/charts/crunchy-postgres/templates/PostgresCluster.yaml
@@ -126,6 +126,14 @@ spec:
             limits:
               cpu: {{ .Values.pgBackRest.sidecars.limits.cpu }}
               memory: {{ .Values.pgBackRest.sidecars.limits.memory }}
+        pgbackrestConfig:
+          resources:
+            requests:
+              cpu: {{ .Values.pgBackRest.sidecars.requests.cpu }}
+              memory: {{ .Values.pgBackRest.sidecars.requests.memory }}
+            limits:
+              cpu: {{ .Values.pgBackRest.sidecars.limits.cpu }}
+              memory: {{ .Values.pgBackRest.sidecars.limits.memory }}
   
   patroni:
     dynamicConfiguration:


### PR DESCRIPTION
There's a container that was added way back last time we upgraded the operator, and it seems like this new container is still missing from the helm chart. I added it and just used the same numbers from the value file as the pgbackrest container. 