### PR TITLE
Update anti-affinity topology key

### DIFF
--- a/charts/crunchy-postgres/templates/PostgresCluster.yaml
+++ b/charts/crunchy-postgres/templates/PostgresCluster.yaml
@@ -66,7 +66,7 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 1
               podAffinityTerm:
-                topologyKey: kubernetes.io/hostname
+                topologyKey: topology.kubernetes.io/zone
                 labelSelector:
                   matchLabels:
                     postgres-operator.crunchydata.com/cluster:
@@ -189,7 +189,7 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 1
               podAffinityTerm:
-                topologyKey: kubernetes.io/hostname
+                topologyKey: topology.kubernetes.io/zone
                 labelSelector:
                   matchLabels:
                     postgres-operator.crunchydata.com/cluster:


### PR DESCRIPTION
Because many nodes are now VMs and those VMs may be on the same VMware host, we want to use the Zone topology key instead of just the hostname. This ensures that if a VMware host fails pods are correctly spread out.