### PR TITLE
standby and a couple small changes

### DIFF
--- a/charts/crunchy-postgres/templates/PostgresCluster.yaml
+++ b/charts/crunchy-postgres/templates/PostgresCluster.yaml
@@ -153,6 +153,9 @@ spec:
             limits:
               cpu: {{ .Values.pgBackRest.sidecars.limits.cpu }}
               memory: {{ .Values.pgBackRest.sidecars.limits.memory }}
+  standby:
+    enabled: {{ .Values.standby.enabled }}
+    repoName: {{ .Values.standby.repoName }}
   
   patroni:
     dynamicConfiguration:

--- a/charts/crunchy-postgres/values.yaml
+++ b/charts/crunchy-postgres/values.yaml
@@ -6,6 +6,11 @@ postgresVersion: 15
 #postGISVersion: '3.3' # use this version of POSTGIS. both crunchyImage and this property needs to have valid values for POSTGIS to be enabled.
 imagePullPolicy: IfNotPresent
 
+# enable to bootstrap a standby cluster from backup. Then disable to promote this standby to primary
+standby:
+  enabled: false
+  # If you want to recover from PVC, use repo1. If you want to recover from S3, use repo2
+  repoName: repo2
 
 instances:
   name: ha # high availability
@@ -56,7 +61,7 @@ pgBackRest:
       cpu: 50m
       memory: 128Mi
   s3:
-    enabled: false
+    enabled: true
     createS3Secret: true
     # the s3 secret name 
     s3Secret: s3-pgbackrest
@@ -65,7 +70,7 @@ pgBackRest:
     # s3UriStyle is host or path
     s3UriStyle: path
     # bucket specifies the S3 bucket to use,
-    bucket: "backetName"
+    bucket: "bucketName"
     # endpoint specifies the S3 endpoint to use.
     endpoint: "endpointName"
     # region specifies the S3 region to use. If your S3 storage system does not
@@ -80,7 +85,7 @@ pgBackRest:
     # setting the below to be one plus of the default schedule
     # to avoid conflicts
     fullSchedule: "0 9 * * *"
-    incrementalSchedule: "0 0,5,13,17,21 * * *"
+    incrementalSchedule: "0 1,5,13,17,21 * * *"
 
 patroni:
   postgresql:

--- a/charts/crunchy-postgres/values.yaml
+++ b/charts/crunchy-postgres/values.yaml
@@ -61,7 +61,7 @@ pgBackRest:
       cpu: 50m
       memory: 128Mi
   s3:
-    enabled: true
+    enabled: false
     createS3Secret: true
     # the s3 secret name 
     s3Secret: s3-pgbackrest

--- a/charts/tools/values.yaml
+++ b/charts/tools/values.yaml
@@ -8,7 +8,7 @@ deployer:
 # Enable the provisioner service account which is used to deploy services to our other namespaces (dev/test/prod)
 # The tools namespace needs to be passed in so we know which namespace to install the service account in and the rolebindings get proper permissions
 provisioner:
-  namespace: # d8d909-tools
+  namespace: #tools-namespace
   serviceAccount:
     enabled: true
 
@@ -26,6 +26,6 @@ networking:
     enabled: true
   # Enable OpenShift route whitch allows you to host your application at a public URL
   route:
-    enabled: true
-    host: # eg: crunchy-postgres.apps.silver.devops.gov.bc.ca
+    enabled: false
+    host: # eg: crunchy-postgres-namespace.apps.silver.devops.gov.bc.ca
 


### PR DESCRIPTION
- Added an option to spin up a standby to recover to a new cluster if necessary. If you enable it and deploy, it'll spin up a standby cluster from the listed repo and recover data from the most recent backup. Then you just disable it to promote the cluster to primary from standby. This serves as an easy way to recover the database from disaster.
- Recommend that the route option is disabled by default. It's probably a better idea for people to turn it on if they want it, rather than expecting people to remember to turn it off if they don't.
- Updated a small typo in bucketName.
- I assume the S3 incr backup schedule was supposed to be 1 hour off the local incr backup schedule, but it was matched up at midnight before, so I fixed that.