### PR TITLE
Support Postgres 14 for Postgres Operator 5.5

### DIFF
--- a/charts/crunchy-postgres/README.md
+++ b/charts/crunchy-postgres/README.md
@@ -10,7 +10,8 @@ A chart to provision a [Crunchy Postgres](https://www.crunchydata.com/) cluster.
 | ------------------ | ---------------------- | ------------------ |
 | `fullnameOverride` | Override release name  | `crunchy-postgres` |
 | `crunchyImage`     | Crunchy Postgres image |                    |
-| `postgresVersion`  | Postgres version       | `14`               |
+| `postgresVersion`  | Postgres version       | `15`               |
+| `isNSX`            | Cluster networking     | `false`            |
 
 ---
 

--- a/charts/crunchy-postgres/templates/_helpers.tpl
+++ b/charts/crunchy-postgres/templates/_helpers.tpl
@@ -40,6 +40,9 @@ helm.sh/chart: {{ include "crunchy-postgres.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.isNSX }}
+DataClass: Medium
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/crunchy-postgres/values.yaml
+++ b/charts/crunchy-postgres/values.yaml
@@ -2,7 +2,11 @@ fullnameOverride: crunchy-postgres
 
 crunchyImage: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
 #crunchyImage: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:ubi8-15.2-3.3-0 # use this image for POSTGIS
+# If setting postgresVersion to 14, also uncomment the pgbackrest image at
+#   .pgBackRest.image below
 postgresVersion: 15
+# Set isNSX to true when deploying to an NSX cluster (Emerald, KLAB2)
+isNSX: false
 #postGISVersion: '3.3' # use this version of POSTGIS. both crunchyImage and this property needs to have valid values for POSTGIS to be enabled.
 imagePullPolicy: IfNotPresent
 
@@ -48,7 +52,9 @@ dataSource:
     stanza: db
 
 pgBackRest:
-  image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
+  # If using Postgres 14 with version 5.5 of the Postgres Operator, uncomment
+  # the following image line, otherwise leave it commented out.
+  #image: "artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbackrest:ubi8-2.49-0"
   retention: "2" # Ideally a larger number such as 30 backups/days
   # If retention-full-type set to 'count' then the oldest backups will expire when the number of backups reach the number defined in retention
   # If retention-full-type set to 'time' then the number defined in retention will take that many days worth of full backups before expiration

--- a/charts/tools/README.md
+++ b/charts/tools/README.md
@@ -61,6 +61,16 @@ Pod network policy to allow pods to accept traffic from other pods in this names
 
 ---
 
+#### Additional network configuration for NSX clusters
+
+Set to 'true' to enable network configuration required in the NSX clusters (Emerald, KLAB2)
+
+| Parameter          | Description                                  | Default |
+| -------------------| -------------------------------------------- | ------- |
+| `networking.isNSX` | Enable operator ingress and DataClass labels | `false` |
+
+---
+
 #### Route
 
 OpenShift route whitch allows you to host your application at a public URL.

--- a/charts/tools/templates/networking/networkPolicy.yaml
+++ b/charts/tools/templates/networking/networkPolicy.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.networking.networkPolicy.enabled (ne .Release.Namespace .Values.provisioner.namespace) }}
+{{- if .Values.networking.networkPolicy.enabled }}
 
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
@@ -11,6 +11,7 @@ spec:
   # to accept traffic from the OpenShift router pods. This is
   # required for things outside of OpenShift (like the Internet)
   # to reach your pods.
+{{- if not .Values.networking.isNSX }}
   ingress:
     - from:
         - namespaceSelector:
@@ -19,5 +20,20 @@ spec:
   podSelector: {}
   policyTypes:
     - Ingress
-    
+{{- else }}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+{{- end -}}
 {{- end }}

--- a/charts/tools/templates/networking/operatorPolicy.yaml
+++ b/charts/tools/templates/networking/operatorPolicy.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.networking.networkPolicy.enabled .Values.networking.isNSX }}
+
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ or .Values.deploymentName .Release.Name }}-operator
+  labels:
+{{ include "crunchy-postgres-tools.labels" . | indent 4}}
+spec:
+  # This policy allows the operator to reach the Crunchy pods
+  egress:
+    - ports:
+        - port: 8432
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-bcgov-crunchy
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-bcgov-crunchy
+      ports:
+        - port: 8432
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: crunchy-postgres
+  policyTypes:
+    - Egress
+    - Ingress
+{{- end }}

--- a/charts/tools/templates/networking/podNetworkPolicy.yaml
+++ b/charts/tools/templates/networking/podNetworkPolicy.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.networking.podNetworkPolicy.enabled (ne .Release.Namespace .Values.provisioner.namespace) }}
+{{- if .Values.networking.podNetworkPolicy.enabled }}
 
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
@@ -7,10 +7,24 @@ metadata:
   labels:
 {{ include "crunchy-postgres-tools.labels" . | indent 4}}
 spec:
+{{- if not .Values.networking.isNSX }}
   # This policy allows pods to accept traffic from other pods in this namespace
   ingress:
     - from:
         - podSelector: {}
   podSelector: {}
+{{- else }}
+  # This policy allows pods to accept traffic from other pods in this namespace
+  egress:
+  - to:
+    - podSelector: {}
+  ingress:
+  - from:
+    - podSelector: {}
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+{{- end -}}
 
 {{ end }}

--- a/charts/tools/values.yaml
+++ b/charts/tools/values.yaml
@@ -8,7 +8,7 @@ deployer:
 # Enable the provisioner service account which is used to deploy services to our other namespaces (dev/test/prod)
 # The tools namespace needs to be passed in so we know which namespace to install the service account in and the rolebindings get proper permissions
 provisioner:
-  namespace: e95e89-tools
+  namespace: ""
   serviceAccount:
     enabled: true
 
@@ -18,6 +18,8 @@ linter:
     enabled: true
 
 networking:
+  # Set isNSX to true if deploying to KLAB2 or Emerald, otherwise leave false
+  isNSX: false
   # Network policy to allow traffic from outside the namespace (like the internet)
   networkPolicy:
     enabled: true

--- a/charts/tools/values.yaml
+++ b/charts/tools/values.yaml
@@ -8,7 +8,7 @@ deployer:
 # Enable the provisioner service account which is used to deploy services to our other namespaces (dev/test/prod)
 # The tools namespace needs to be passed in so we know which namespace to install the service account in and the rolebindings get proper permissions
 provisioner:
-  namespace: #tools-namespace
+  namespace: e95e89-tools
   serviceAccount:
     enabled: true
 


### PR DESCRIPTION
Version 5.5 of the Postgres Operator dropped support for Postgres version 14.  Enable that, in conjunction with an update to the Crunchy Operator role in the Cluster Configuration Management system, and add support for NSX clusters.