### PR TITLE
Fix 2 issues related to DataSource and remove PostGIS comment

### DIFF
--- a/charts/crunchy-postgres/templates/PostgresCluster.yaml
+++ b/charts/crunchy-postgres/templates/PostgresCluster.yaml
@@ -90,6 +90,7 @@ spec:
             name: {{ .Values.dataSource.secretName }}
       global:
         repo2-path: {{ .Values.dataSource.repo.path }}
+        repo2-s3-uri-style: {{ .Values.dataSource.repo.s3UriStyle }}
       repo:
         name: {{ .Values.dataSource.repo.name }}
         s3:

--- a/charts/crunchy-postgres/templates/PostgresCluster.yaml
+++ b/charts/crunchy-postgres/templates/PostgresCluster.yaml
@@ -97,7 +97,7 @@ spec:
           bucket: {{ .Values.dataSource.repo.s3.bucket }}
           endpoint: {{ .Values.dataSource.repo.s3.endpoint }}
           region: {{ .Values.dataSource.repo.s3.region }}
-      stanza: {{ .Values.dataSource.stanza }}
+      stanza: {{ .Values.dataSource.repo.stanza }}
   {{ end }}
   
   backups:

--- a/charts/crunchy-postgres/values.yaml
+++ b/charts/crunchy-postgres/values.yaml
@@ -40,6 +40,8 @@ dataSource:
   secretName: s3-pgbackrest
   repo:
     name: repo2
+    # s3UriStyle is host or path
+    s3UriStyle: path
     path: "/habackup"
     s3:
       bucket: "bucketName"

--- a/charts/crunchy-postgres/values.yaml
+++ b/charts/crunchy-postgres/values.yaml
@@ -1,9 +1,8 @@
 fullnameOverride: crunchy-postgres
 
 crunchyImage: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
-#crunchyImage: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:ubi8-15.2-3.3-0 # use this image for POSTGIS
 postgresVersion: 15
-#postGISVersion: '3.3' # use this version of POSTGIS. both crunchyImage and this property needs to have valid values for POSTGIS to be enabled.
+#postGISVersion: '3.3' # use this version of POSTGIS.
 imagePullPolicy: IfNotPresent
 
 # enable to bootstrap a standby cluster from backup. Then disable to promote this standby to primary


### PR DESCRIPTION
To be able to restore from the BC Gov S3 service we need to set repo2-s3-uri-style to 'path'. This adds that to the PostgresCluster.yaml and values.yaml file. It also corrects the source for 'stanza'

I also removed the comment around setting the CrunchyImage variable when enabling POSTGIS as that is not required and will cause issues.